### PR TITLE
Find largest continuous rectangle in a histogram

### DIFF
--- a/stack/LrgRecHistogram.java
+++ b/stack/LrgRecHistogram.java
@@ -1,0 +1,37 @@
+package stack;
+
+import java.util.Arrays;
+import java.util.Stack;
+
+public class LrgRecHistogram{
+    
+    public int largestRectangleArea(int[] heights){
+        Stack<Integer> stack = new Stack();
+        stack.push(-1);
+        int maxArea = 0;
+
+        for(int i=0; i<heights.length;i++){
+            while(stack.peek() != -1 && heights[i] <= heights[stack.peek()]){
+                int height = heights[stack.pop()];
+                int width = i - stack.peek()-1;
+                maxArea = Math.max(maxArea, height* width);
+            }
+            stack.push(i);
+        }
+
+        while(stack.peek() != -1){
+            int height = heights[stack.pop()];
+            int width = heights.length - stack.peek() -1;
+            maxArea = Math.max(maxArea, height* width);
+        }
+        return maxArea;
+    }
+
+    public static void main(String[] args) {
+        LrgRecHistogram largest = new LrgRecHistogram();
+        int[] heights = {2,1,5,6,2,3};
+
+        System.out.println(Arrays.toString(heights));
+        System.out.println(largest.largestRectangleArea(heights));
+    }
+}


### PR DESCRIPTION
84. Largest Rectangle in Histogram

Given an array of integers heights representing the histogram's bar height where the width of each bar is 1, return the area of the largest rectangle in the histogram.

Example 1:

Input: heights = [2,1,5,6,2,3]
Output: 10
Explanation: The above is a histogram where width of each bar is 1.
The largest rectangle is shown in the red area, which has an area = 10 units.